### PR TITLE
Expose API port & and upgrade to v1.4.3

### DIFF
--- a/crowdsec-firewall-bouncer/Dockerfile
+++ b/crowdsec-firewall-bouncer/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     mkdir -p /var/run/crowdsec/ && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/crowdsecurity/cs-firewall-bouncer/releases/download/v0.0.24-rc1/crowdsec-firewall-bouncer-${BUILD_ARCH}.tgz /crowdsec-firewall-bouncer.tgz
+ADD https://github.com/crowdsecurity/cs-firewall-bouncer/releases/download/v0.0.24/crowdsec-firewall-bouncer-${BUILD_ARCH}.tgz /crowdsec-firewall-bouncer.tgz
 
 RUN tar xzvf /crowdsec-firewall-bouncer.tgz && rm /crowdsec-firewall-bouncer.tgz && mv /crowdsec-firewall-bouncer-v0.0.24-rc1/crowdsec-firewall-bouncer /crowdsec-firewall-bouncer
 

--- a/crowdsec-firewall-bouncer/config.yaml
+++ b/crowdsec-firewall-bouncer/config.yaml
@@ -13,8 +13,6 @@ arch:
   - aarch64
   - armv7
   - i386
-ports:
-  8080/tcp: null
 image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec-firewall-bouncer"
 options:
   api_url: "http://424ccef4-crowdsec:8080/"

--- a/crowdsec-firewall-bouncer/config.yaml
+++ b/crowdsec-firewall-bouncer/config.yaml
@@ -13,6 +13,8 @@ arch:
   - aarch64
   - armv7
   - i386
+ports:
+  8080/tcp: null
 image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec-firewall-bouncer"
 options:
   api_url: "http://424ccef4-crowdsec:8080/"

--- a/crowdsec/Dockerfile
+++ b/crowdsec/Dockerfile
@@ -43,21 +43,21 @@ RUN apt-get install -y -q --install-recommends --no-install-suggests \
 #Add alias until env variables will be supported by crowdsec.
 RUN echo 'alias cscli="cscli -c /config/.storage/crowdsec/config/config.yaml"' > /root/.bashrc
 
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec /etc/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/var/lib/crowdsec /var/lib/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /usr/local/bin/crowdsec /usr/local/bin/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /usr/local/bin/cscli /usr/local/bin/cscli
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /docker_start.sh /docker_start.sh
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec/config.yaml /etc/crowdsec/config.yaml
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec /etc/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/var/lib/crowdsec /var/lib/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /usr/local/bin/crowdsec /usr/local/bin/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /usr/local/bin/cscli /usr/local/bin/cscli
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /docker_start.sh /docker_start.sh
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec/config.yaml /etc/crowdsec/config.yaml
 #Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
 #The files are here for reference, as users will need to mount a new version to be actually able to use notifications
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec/notifications/email.yaml /etc/crowdsec/notifications/email.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec/notifications/http.yaml /etc/crowdsec/notifications/http.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec/notifications/slack.yaml /etc/crowdsec/notifications/slack.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /staging/etc/crowdsec/notifications/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec/notifications/email.yaml /etc/crowdsec/notifications/email.yaml
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec/notifications/http.yaml /etc/crowdsec/notifications/http.yaml
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec/notifications/slack.yaml /etc/crowdsec/notifications/slack.yaml
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /staging/etc/crowdsec/notifications/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
 # workaround to avoid having build issue ("failed to create image: failed to get layer")
 RUN true
-COPY --from=crowdsecurity/crowdsec:v1.4.1-debian /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
+COPY --from=crowdsecurity/crowdsec:v1.4.3-debian /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
 
 # Copy root filesystem
 COPY rootfs /

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.1-ha1"
+version: "1.4.3"
 slug: "crowdsec"
 init: false
 ingress: true
@@ -15,7 +15,6 @@ arch:
   - i386
 ports:
   8080/tcp: null
-image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec"
 options:
   acquisition: |
     ---

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.3"
+version: "1.4.1-ha1"
 slug: "crowdsec"
 init: false
 ingress: true

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -15,6 +15,7 @@ arch:
   - i386
 ports:
   8080/tcp: null
+image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec"
 options:
   acquisition: |
     ---

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.1-ha1"
+version: "1.4.3"
 slug: "crowdsec"
 init: false
 ingress: true

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "v1.4.3-debian"
+version: "1.4.1-ha1"
 slug: "crowdsec"
 init: false
 ingress: true
@@ -13,7 +13,9 @@ arch:
   - aarch64
   - armv7
   - i386
-image: "crowdsecurity/crowdsec"
+ports:
+  8080/tcp: null
+image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec"
 options:
   acquisition: |
     ---

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.1-ha1"
+version: "1.4.3-ha1"
 slug: "crowdsec"
 init: false
 ingress: true

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.3"
+version: "v1.4.3-debian"
 slug: "crowdsec"
 init: false
 ingress: true
@@ -13,7 +13,7 @@ arch:
   - aarch64
   - armv7
   - i386
-image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec"
+image: "crowdsecurity/crowdsec"
 options:
   acquisition: |
     ---


### PR DESCRIPTION
This adds the ability to expose ports, such as for the API, on the Docker host. This is useful/required if the crowdsec bouncer is external to the Docker host running Home Assistant.