### PR TITLE
update libsystemd for journalctl + bump crowdsec version

### DIFF
--- a/crowdsec/Dockerfile
+++ b/crowdsec/Dockerfile
@@ -40,24 +40,26 @@ RUN apt-get install -y -q --install-recommends --no-install-suggests \
     && chmod +x /usr/bin/ttyd \
     && mkdir -p /etc/crowdsec \
     && mkdir -p /var/lib/crowdsec
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list \
+    && apt-get update && apt-get install -t bullseye-backports -y libsystemd0
 #Add alias until env variables will be supported by crowdsec.
 RUN echo 'alias cscli="cscli -c /config/.storage/crowdsec/config/config.yaml"' > /root/.bashrc
 
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec /etc/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/var/lib/crowdsec /var/lib/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /usr/local/bin/crowdsec /usr/local/bin/crowdsec
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /usr/local/bin/cscli /usr/local/bin/cscli
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /docker_start.sh /docker_start.sh
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec/config.yaml /etc/crowdsec/config.yaml
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec /etc/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/var/lib/crowdsec /var/lib/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /usr/local/bin/crowdsec /usr/local/bin/crowdsec
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /usr/local/bin/cscli /usr/local/bin/cscli
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /docker_start.sh /docker_start.sh
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec/config.yaml /etc/crowdsec/config.yaml
 #Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
 #The files are here for reference, as users will need to mount a new version to be actually able to use notifications
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec/notifications/email.yaml /etc/crowdsec/notifications/email.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec/notifications/http.yaml /etc/crowdsec/notifications/http.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec/notifications/slack.yaml /etc/crowdsec/notifications/slack.yaml
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /staging/etc/crowdsec/notifications/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec/notifications/email.yaml /etc/crowdsec/notifications/email.yaml
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec/notifications/http.yaml /etc/crowdsec/notifications/http.yaml
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec/notifications/slack.yaml /etc/crowdsec/notifications/slack.yaml
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /staging/etc/crowdsec/notifications/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
 # workaround to avoid having build issue ("failed to create image: failed to get layer")
 RUN true
-COPY --from=crowdsecurity/crowdsec:v1.4.6-debian /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
+COPY --from=crowdsecurity/crowdsec:v1.5.2-debian /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
 
 # Copy root filesystem
 COPY rootfs /

--- a/crowdsec/build.yaml
+++ b/crowdsec/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  amd64: "ghcr.io/home-assistant/amd64-base-debian"
-  armhf: "ghcr.io/home-assistant/armhf-base-debian"
-  aarch64: "ghcr.io/home-assistant/aarch64-base-debian"
-  armv7: "ghcr.io/home-assistant/armv7-base-debian"
-  i386: "ghcr.io/home-assistant/i386-base-debian"
+  amd64: "ghcr.io/home-assistant/amd64-base-debian:bullseye"
+  armhf: "ghcr.io/home-assistant/armhf-base-debian:bullseye"
+  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bullseye"
+  armv7: "ghcr.io/home-assistant/armv7-base-debian:bullseye"
+  i386: "ghcr.io/home-assistant/i386-base-debian:bullseye"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Crowdsec add-on"
   org.opencontainers.image.description: "CrowdSec - the open-source and participative IPS."

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -1,7 +1,7 @@
 name: "Crowdsec"
 description: "CrowdSec - the open-source and participative IPS"
 url: "https://github.com/crowdsecurity/home-assistant-addons/blob/main/crowdsec/DOCS.md"
-version: "1.4.6"
+version: "1.5.2"
 slug: "crowdsec"
 init: false
 ingress: true


### PR DESCRIPTION
* fix https://github.com/crowdsecurity/home-assistant-addons/issues/38
* bump crowdsec version to 1.5.2

The backward compatibility was tested :+1: 