### PR TITLE
Bypass volume check

### DIFF
--- a/crowdsec/rootfs/etc/services.d/crowdsec/run
+++ b/crowdsec/rootfs/etc/services.d/crowdsec/run
@@ -143,4 +143,8 @@ if [[ ! -z "${scenarios_to_disable}" ]]; then
     export DISABLE_SCENARIOS="${DISABLE_SCENARIOS}"
 fi
 
+# In Home Assistant, the user does not have control over the volumes (it's managed by the add-on)
+# And crowdsec is using not default paths, which breaks the check done in the entrypoint
+export CROWDSEC_BYPASS_DB_VOLUME_CHECK=true
+
 exec bash /docker_start.sh


### PR DESCRIPTION
Bypass the volume check added in crowdsec 1.7.0 for docker: the volumes are managed by the add-on, and we are not using the default crowdsec paths and this breaks the check done in the docker start script.

Because we know the config/db is stored in a volume, we can just ignore the check.