### PR TITLE
Add TLS/mTLS authentication support for remote LAPI connections

### DIFF
--- a/crowdsec-firewall-bouncer/CHANGELOG.md
+++ b/crowdsec-firewall-bouncer/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add TLS/mTLS authentication support for connecting to remote LAPI
+- Add `tls_enabled`, `tls_ca_cert`, `tls_client_cert`, `tls_client_key`, `tls_skip_verify` configuration options
+- Add `/ssl` directory mount for certificate access
+
+## v0.0.34
+
+- Initial tracked version

--- a/crowdsec-firewall-bouncer/DOCS.md
+++ b/crowdsec-firewall-bouncer/DOCS.md
@@ -21,7 +21,7 @@ To generate an bouncer API key, we need to access to the [CrowdSec Terminal](htt
 
 ```bash
 root@424ccef4-crowdsec:~# cscli bouncers add cs-firewall-bouncer
-INFO[17-05-2022 03:23:36 PM] push and pull to Central API disabled        
+INFO[17-05-2022 03:23:36 PM] push and pull to Central API disabled
 Api key for 'cs-firewall-bouncer':
 
    a44bdb2ea50224f763015d04d2cd2e4b
@@ -29,7 +29,7 @@ Api key for 'cs-firewall-bouncer':
 Please keep this key since you will not be able to retrieve it!
 ```
 
-The API Key and API URL need to be shared from the CrowdSec add-on to the Bouncer add-on. These details can be added through the Home Assistant UI `Settings > Add-Ons > CrowdSec Firewall Bouncer > Configuration`, or by editing `/config/.storage/crowdsec/config/local_api_configuration.yaml` directly. 
+The API Key and API URL need to be shared from the CrowdSec add-on to the Bouncer add-on. These details can be added through the Home Assistant UI `Settings > Add-Ons > CrowdSec Firewall Bouncer > Configuration`, or by editing `/config/.storage/crowdsec/config/local_api_configuration.yaml` directly.
 
 The API URL should be input as: `http://<crowdsec-terminal-hostname>:8080/`
 
@@ -42,6 +42,11 @@ api_url: "http://424ccef4-crowdsec:8080/"
 api_key: "a44bdb2ea50224f763015d04d2cd2e4b"
 update_frequency: "10s"
 log_level: info
+tls_enabled: false
+tls_ca_cert: ""
+tls_client_cert: ""
+tls_client_key: ""
+tls_skip_verify: false
 ```
 
 ### Option: `api_url` (required)
@@ -58,7 +63,7 @@ Controls how often the bouncer is going to query the local API.
 
 ### Option: `nftables_hooks` (optional)
 
-Controls the nftables hooks to use to configure multiple chains. 
+Controls the nftables hooks to use to configure multiple chains.
 Can be:
 
 * `prerouting`
@@ -71,6 +76,54 @@ Can be:
 ### Option: `log_level` (optional)
 
 Controls logging level.
+
+### Option: `tls_enabled` (optional)
+
+Enable TLS client authentication for connecting to a remote LAPI. When enabled, certificate files must be placed in Home Assistant's `/ssl/` directory.
+
+### Option: `tls_ca_cert` (optional)
+
+Filename of the CA certificate in `/ssl/` directory. Used to verify the remote LAPI server certificate.
+
+### Option: `tls_client_cert` (optional)
+
+Filename of the client certificate in `/ssl/` directory. Used for mTLS authentication with the remote LAPI.
+
+### Option: `tls_client_key` (optional)
+
+Filename of the client private key in `/ssl/` directory. Must match the client certificate.
+
+### Option: `tls_skip_verify` (optional)
+
+Skip TLS certificate verification. **Warning: This is insecure and should only be used for testing.**
+
+## TLS Authentication
+
+To connect to a remote LAPI using TLS/mTLS authentication instead of API key authentication:
+
+### 1. Place certificates in Home Assistant's SSL directory
+
+Copy your certificates to `/ssl/` (accessible via Home Assistant's file editor or SSH):
+- `ca.crt` - CA certificate that signed the LAPI server certificate
+- `bouncer.crt` - Client certificate for this bouncer
+- `bouncer.key` - Client private key
+
+### 2. Configure the add-on
+
+```yaml
+api_url: "https://your-lapi-server:8080/"
+api_key: ""
+tls_enabled: true
+tls_ca_cert: "ca.crt"
+tls_client_cert: "bouncer.crt"
+tls_client_key: "bouncer.key"
+```
+
+When using TLS authentication with mTLS (client certificates), `api_key` can be left empty.
+
+### 3. Generate certificates (if needed)
+
+On your CrowdSec LAPI server, you can generate certificates using your preferred CA. See the [CrowdSec TLS documentation](https://doc.crowdsec.net/docs/local_api/tls_auth) for details on configuring TLS authentication.
 
 ## Support
 

--- a/crowdsec-firewall-bouncer/config.yaml
+++ b/crowdsec-firewall-bouncer/config.yaml
@@ -17,16 +17,27 @@ image: "ghcr.io/crowdsecurity/{arch}-addon-crowdsec-firewall-bouncer"
 options:
   api_url: "http://424ccef4-crowdsec:8080/"
   api_key: ""
+  tls_enabled: false
+  tls_ca_cert: ""
+  tls_client_cert: ""
+  tls_client_key: ""
+  tls_skip_verify: false
   update_frequency: "10s"
   log_level: info
   nftables_hooks:
     - input
 schema:
   api_url: str
-  api_key: str
+  api_key: str?
+  tls_enabled: bool?
+  tls_ca_cert: str?
+  tls_client_cert: str?
+  tls_client_key: str?
+  tls_skip_verify: bool?
   update_frequency: str
-  nftables_hooks: 
+  nftables_hooks:
     - "match(^(prerouting|input|forward|output|postrouting|ingress)$)"
   log_level: list(info|error|debug)
 map:
   - config:rw
+  - ssl:ro

--- a/crowdsec-firewall-bouncer/rootfs/etc/crowdsec-firewall-bouncer/config.yaml
+++ b/crowdsec-firewall-bouncer/rootfs/etc/crowdsec-firewall-bouncer/config.yaml
@@ -7,7 +7,8 @@ log_dir: /var/log/
 log_level: {LOG_LEVEL}
 api_url: {API_URL}
 api_key: {API_KEY}
-insecure_skip_verify: false
+insecure_skip_verify: {TLS_SKIP_VERIFY}
+{TLS_CONFIG}
 disable_ipv6: false
 deny_action: DROP
 deny_log: true

--- a/crowdsec-firewall-bouncer/rootfs/etc/services.d/crowdsec-firewall-bouncer/run
+++ b/crowdsec-firewall-bouncer/rootfs/etc/services.d/crowdsec-firewall-bouncer/run
@@ -4,6 +4,11 @@
 declare api_url
 declare api_key
 declare update_frequency
+declare tls_enabled
+declare tls_ca_cert
+declare tls_client_cert
+declare tls_client_key
+declare tls_skip_verify
 
 # Get all arguments
 api_url=$(bashio::config 'api_url')
@@ -15,6 +20,11 @@ nftables_hooks="\n"
 for item in ${nftables_hooks_tmp}; do
   nftables_hooks+="  - ${item}\n"
 done
+tls_enabled=$(bashio::config 'tls_enabled')
+tls_ca_cert=$(bashio::config 'tls_ca_cert')
+tls_client_cert=$(bashio::config 'tls_client_cert')
+tls_client_key=$(bashio::config 'tls_client_key')
+tls_skip_verify=$(bashio::config 'tls_skip_verify')
 
 bashio::log.info "Running Crowdsec addon"
 bashio::log.info "-> Replacing environment variables"
@@ -23,6 +33,72 @@ sed -i "s|{API_KEY}|${api_key}|" /etc/crowdsec-firewall-bouncer/config.yaml
 sed -i "s|{UPDATE_FREQUENCY}|${update_frequency}|" /etc/crowdsec-firewall-bouncer/config.yaml
 sed -i "s|{LOG_LEVEL}|${log_level}|" /etc/crowdsec-firewall-bouncer/config.yaml
 sed -i "s|{NFTABLES_HOOKS}|${nftables_hooks}|" /etc/crowdsec-firewall-bouncer/config.yaml
+
+# Handle TLS configuration
+if bashio::var.true "${tls_enabled}"; then
+    bashio::log.info "-> Configuring TLS authentication"
+
+    # Validate CA certificate
+    if [[ -n "${tls_ca_cert}" ]]; then
+        if [[ "${tls_ca_cert}" == *".."* ]]; then
+            bashio::log.error "Invalid CA certificate path: path traversal not allowed"
+            exit 1
+        fi
+        if [[ ! -f "/ssl/${tls_ca_cert}" ]]; then
+            bashio::log.error "CA certificate not found: /ssl/${tls_ca_cert}"
+            exit 1
+        fi
+        bashio::log.info "   CA certificate: /ssl/${tls_ca_cert}"
+    fi
+
+    # Validate client certificate
+    if [[ -n "${tls_client_cert}" ]]; then
+        if [[ "${tls_client_cert}" == *".."* ]]; then
+            bashio::log.error "Invalid client certificate path: path traversal not allowed"
+            exit 1
+        fi
+        if [[ ! -f "/ssl/${tls_client_cert}" ]]; then
+            bashio::log.error "Client certificate not found: /ssl/${tls_client_cert}"
+            exit 1
+        fi
+        bashio::log.info "   Client certificate: /ssl/${tls_client_cert}"
+    fi
+
+    # Validate client key
+    if [[ -n "${tls_client_key}" ]]; then
+        if [[ "${tls_client_key}" == *".."* ]]; then
+            bashio::log.error "Invalid client key path: path traversal not allowed"
+            exit 1
+        fi
+        if [[ ! -f "/ssl/${tls_client_key}" ]]; then
+            bashio::log.error "Client key not found: /ssl/${tls_client_key}"
+            exit 1
+        fi
+        bashio::log.info "   Client key: /ssl/${tls_client_key}"
+    fi
+
+    # Write TLS config to temp file (root level, not nested under tls:)
+    {
+        [[ -n "${tls_ca_cert}" ]] && echo "ca_cert_path: /ssl/${tls_ca_cert}"
+        [[ -n "${tls_client_cert}" ]] && echo "cert_path: /ssl/${tls_client_cert}"
+        [[ -n "${tls_client_key}" ]] && echo "key_path: /ssl/${tls_client_key}"
+    } > /tmp/tls_config.yaml
+
+    # Insert TLS config and remove placeholder
+    sed -i -e '/{TLS_CONFIG}/r /tmp/tls_config.yaml' -e '/{TLS_CONFIG}/d' \
+        /etc/crowdsec-firewall-bouncer/config.yaml
+    rm -f /tmp/tls_config.yaml
+else
+    sed -i "s|{TLS_CONFIG}||" /etc/crowdsec-firewall-bouncer/config.yaml
+fi
+
+# Handle TLS skip verify
+if bashio::var.true "${tls_skip_verify}"; then
+    bashio::log.warning "TLS certificate verification disabled - this is insecure!"
+    sed -i "s|{TLS_SKIP_VERIFY}|true|" /etc/crowdsec-firewall-bouncer/config.yaml
+else
+    sed -i "s|{TLS_SKIP_VERIFY}|false|" /etc/crowdsec-firewall-bouncer/config.yaml
+fi
 
 bashio::log.info "-> Validating config file"
 /crowdsec-firewall-bouncer -c /etc/crowdsec-firewall-bouncer/config.yaml -t

--- a/crowdsec/CHANGELOG.md
+++ b/crowdsec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add TLS/mTLS authentication support for connecting to remote LAPI
+- Add `tls_enabled`, `tls_ca_cert`, `tls_client_cert`, `tls_client_key`, `tls_skip_verify` configuration options
+- Add `/ssl` directory mount for certificate access
+
 ## 1.7.4
 
 - Bump crowdsec version to 1.7.4

--- a/crowdsec/DOCS.md
+++ b/crowdsec/DOCS.md
@@ -39,7 +39,7 @@ This add-on has also persistent config and data files that are store at `/config
 acquisition: |
   ---
   source: journalctl
-  journalctl_filter: 
+  journalctl_filter:
     - "--directory=/var/log/journal/"
   labels:
     type: syslog
@@ -56,6 +56,11 @@ parsers_to_disable:
   - crowdsecurity/whitelists
 scenarios_to_disable: []
 disable_online_api: false
+tls_enabled: false
+tls_ca_cert: ""
+tls_client_cert: ""
+tls_client_key: ""
+tls_skip_verify: false
 ```
 
 ### Option: `acquisition` (required)
@@ -106,6 +111,54 @@ All the scenarios you want to remove before running crowdsec.
 ### Option: `disable_online_api` (optional)
 
 Disable Online API registration for signal sharing.
+
+### Option: `tls_enabled` (optional)
+
+Enable TLS client authentication for connecting to a remote LAPI. When enabled, certificate files must be placed in Home Assistant's `/ssl/` directory.
+
+### Option: `tls_ca_cert` (optional)
+
+Filename of the CA certificate in `/ssl/` directory. Used to verify the remote LAPI server certificate.
+
+### Option: `tls_client_cert` (optional)
+
+Filename of the client certificate in `/ssl/` directory. Used for mTLS authentication with the remote LAPI.
+
+### Option: `tls_client_key` (optional)
+
+Filename of the client private key in `/ssl/` directory. Must match the client certificate.
+
+### Option: `tls_skip_verify` (optional)
+
+Skip TLS certificate verification. **Warning: This is insecure and should only be used for testing.**
+
+## TLS Authentication
+
+To connect to a remote LAPI using TLS/mTLS authentication instead of password-based auth:
+
+### 1. Place certificates in Home Assistant's SSL directory
+
+Copy your certificates to `/ssl/` (accessible via Home Assistant's file editor or SSH):
+- `ca.crt` - CA certificate that signed the LAPI server certificate
+- `agent.crt` - Client certificate for this agent
+- `agent.key` - Client private key
+
+### 2. Configure the add-on
+
+```yaml
+disable_lapi: true
+remote_lapi_url: "https://your-lapi-server:8080"
+tls_enabled: true
+tls_ca_cert: "ca.crt"
+tls_client_cert: "agent.crt"
+tls_client_key: "agent.key"
+```
+
+When using TLS authentication, `agent_username` and `agent_password` are not required.
+
+### 3. Generate certificates (if needed)
+
+On your CrowdSec LAPI server, you can generate certificates using your preferred CA. See the [CrowdSec TLS documentation](https://doc.crowdsec.net/docs/local_api/tls_auth) for details on configuring TLS authentication.
 
 ## Support
 

--- a/crowdsec/config.yaml
+++ b/crowdsec/config.yaml
@@ -22,7 +22,7 @@ options:
   acquisition: |
     ---
     source: journalctl
-    journalctl_filter: 
+    journalctl_filter:
       - "--directory=/var/log/journal/"
     labels:
       type: syslog
@@ -30,6 +30,11 @@ options:
   remote_lapi_url: ""
   agent_username: ""
   agent_password: ""
+  tls_enabled: false
+  tls_ca_cert: ""
+  tls_client_cert: ""
+  tls_client_key: ""
+  tls_skip_verify: false
   collections:
     - crowdsecurity/home-assistant
   parsers: []
@@ -44,8 +49,13 @@ schema:
   acquisition: str
   disable_lapi: bool
   remote_lapi_url: str
-  agent_username: str
-  agent_password: str
+  agent_username: str?
+  agent_password: str?
+  tls_enabled: bool?
+  tls_ca_cert: str?
+  tls_client_cert: str?
+  tls_client_key: str?
+  tls_skip_verify: bool?
   collections:
     - str
   parsers:
@@ -61,6 +71,7 @@ schema:
   disable_online_api: bool
 map:
   - config:rw
+  - ssl:ro
 panel_icon: mdi:console-network
 panel_title: Crowdsec Terminal
 journald: true

--- a/crowdsec/rootfs/etc/services.d/crowdsec/run
+++ b/crowdsec/rootfs/etc/services.d/crowdsec/run
@@ -15,6 +15,11 @@ declare postoverflows
 declare parsers_to_disable
 declare scenarios_to_disable
 declare disable_online_api
+declare tls_enabled
+declare tls_ca_cert
+declare tls_client_cert
+declare tls_client_key
+declare tls_skip_verify
 
 # Get all arguments
 acquisition=$(bashio::config 'acquisition')
@@ -29,6 +34,11 @@ postoverflows=$(bashio::config 'postoverflows')
 parsers_to_disable=$(bashio::config 'parsers_to_disable')
 scenarios_to_disable=$(bashio::config 'scenarios_to_disable')
 disable_online_api=$(bashio::config 'disable_online_api')
+tls_enabled=$(bashio::config 'tls_enabled')
+tls_ca_cert=$(bashio::config 'tls_ca_cert')
+tls_client_cert=$(bashio::config 'tls_client_cert')
+tls_client_key=$(bashio::config 'tls_client_key')
+tls_skip_verify=$(bashio::config 'tls_skip_verify')
 
 # Copy Crowdsec config and data files to make it persistent if it's not already
 if [ -d "/config/.storage/crowdsec/config/" ]; then
@@ -63,15 +73,81 @@ echo "${acquisition}" > /config/.storage/crowdsec/config/acquis.yaml
 
 # Local API settings
 if bashio::var.true "${disable_lapi}"; then
-    bashio::log.info "Disabling Local API and checking credentials..."
-    if [[ -z "${remote_lapi_url}" ]] || [[ -z "${agent_username}" ]] || [[ -z "${agent_password}" ]]; then
-        bashio::log.error "When disabling lapi, you need to provide remote 'remote_lapi_url', 'agent_username' and 'agent_password'"
+    bashio::log.info "Disabling Local API..."
+
+    if [[ -z "${remote_lapi_url}" ]]; then
+        bashio::log.error "When disabling lapi, you need to provide 'remote_lapi_url'"
         exit 1
     fi
+
     export DISABLE_LOCAL_API=true
-    export LOCAL_API_URL="${remote_lapi_url}"
-    export AGENT_USERNAME="${agent_username}"
-    export AGENT_PASSWORD="${agent_password}"
+
+    # Check if using TLS authentication
+    if bashio::var.true "${tls_enabled}"; then
+        bashio::log.info "Using TLS authentication for remote LAPI"
+
+        # Tell docker entrypoint to enable TLS mode
+        export USE_TLS=true
+        export LOCAL_API_URL="${remote_lapi_url}"
+
+        # Validate and set CA certificate
+        if [[ -n "${tls_ca_cert}" ]]; then
+            if [[ "${tls_ca_cert}" == *".."* ]]; then
+                bashio::log.error "Invalid CA certificate path: path traversal not allowed"
+                exit 1
+            fi
+            if [[ ! -f "/ssl/${tls_ca_cert}" ]]; then
+                bashio::log.error "CA certificate not found: /ssl/${tls_ca_cert}"
+                exit 1
+            fi
+            export CACERT_FILE="/ssl/${tls_ca_cert}"
+            bashio::log.info "  CA certificate: /ssl/${tls_ca_cert}"
+        fi
+
+        # Validate and set client certificate
+        if [[ -n "${tls_client_cert}" ]]; then
+            if [[ "${tls_client_cert}" == *".."* ]]; then
+                bashio::log.error "Invalid client certificate path: path traversal not allowed"
+                exit 1
+            fi
+            if [[ ! -f "/ssl/${tls_client_cert}" ]]; then
+                bashio::log.error "Client certificate not found: /ssl/${tls_client_cert}"
+                exit 1
+            fi
+            export CLIENT_CERT_FILE="/ssl/${tls_client_cert}"
+            bashio::log.info "  Client certificate: /ssl/${tls_client_cert}"
+        fi
+
+        # Validate and set client key
+        if [[ -n "${tls_client_key}" ]]; then
+            if [[ "${tls_client_key}" == *".."* ]]; then
+                bashio::log.error "Invalid client key path: path traversal not allowed"
+                exit 1
+            fi
+            if [[ ! -f "/ssl/${tls_client_key}" ]]; then
+                bashio::log.error "Client key not found: /ssl/${tls_client_key}"
+                exit 1
+            fi
+            export CLIENT_KEY_FILE="/ssl/${tls_client_key}"
+            bashio::log.info "  Client key: /ssl/${tls_client_key}"
+        fi
+
+        # Handle skip verify option
+        if bashio::var.true "${tls_skip_verify}"; then
+            bashio::log.warning "TLS certificate verification disabled - this is insecure!"
+            export INSECURE_SKIP_VERIFY=true
+        fi
+    else
+        # Password-based authentication
+        bashio::log.info "Using password authentication for remote LAPI"
+        if [[ -z "${agent_username}" ]] || [[ -z "${agent_password}" ]]; then
+            bashio::log.error "Password auth requires 'agent_username' and 'agent_password'"
+            exit 1
+        fi
+        export LOCAL_API_URL="${remote_lapi_url}"
+        export AGENT_USERNAME="${agent_username}"
+        export AGENT_PASSWORD="${agent_password}"
+    fi
 fi
 
 # Disable or not the Online API


### PR DESCRIPTION
Add TLS as an alternative method of authentication to remote LAPIs. Certs are read from the read-only-mounted `/ssl` directory.

Fixes #42 